### PR TITLE
HF-2-create-account-and-household-api-endpoints

### DIFF
--- a/app/api/accounts.py
+++ b/app/api/accounts.py
@@ -1,0 +1,86 @@
+from fastapi import APIRouter, HTTPException
+from uuid import UUID, uuid4
+from datetime import datetime, timezone
+from app.models.schemas import Account, Household, User
+from app.services.storage import load_versions, save_version, mark_old_version_as_stale
+
+router = APIRouter()
+
+
+@router.post("/")
+def create_account(name: str):
+    account = Account(
+        account_id=uuid4(),
+        name=name,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        is_current=True,
+        is_deleted=False
+    )
+    save_version(account, "accounts", "account_id")
+    return {"message": "Account created", "account_id": str(account.account_id)}
+
+
+@router.put("/{account_id}")
+def update_account(account_id: UUID, name: str):
+    mark_old_version_as_stale("accounts", account_id, "account_id")
+    accounts = load_versions("accounts")
+    current = accounts[accounts["account_id"] == str(account_id)].iloc[-1].to_dict()
+    updated = Account(
+        account_id=account_id,
+        name=name,
+        created_at=current["created_at"],
+        updated_at=datetime.now(timezone.utc),
+        is_current=True,
+        is_deleted=False
+    )
+    save_version(updated, "accounts", "account_id")
+    return {"message": "Account updated", "account_id": str(account_id)}
+
+
+@router.post("/{account_id}/delete")
+def soft_delete_account(account_id: UUID):
+    mark_old_version_as_stale("accounts", account_id, "account_id")
+    accounts = load_versions("accounts")
+    current = accounts[accounts["account_id"] == str(account_id)].iloc[-1].to_dict()
+    deleted = Account(
+        account_id=account_id,
+        name=current["name"],
+        created_at=current["created_at"],
+        updated_at=datetime.now(timezone.utc),
+        is_current=True,
+        is_deleted=True
+    )
+    save_version(deleted, "accounts", "account_id")
+    return {"message": "Account deleted", "account_id": str(account_id)}
+
+
+@router.get("/")
+def list_accounts():
+    accounts = load_versions("accounts")
+    current = accounts[(accounts["is_current"] == True) & (accounts["is_deleted"] == False)]
+    return current.to_dict(orient="records")
+
+
+@router.get("   /{account_id}")
+def get_account(account_id: UUID):
+    accounts = load_versions("accounts")
+    record = accounts[(accounts["account_id"] == str(account_id)) & (accounts["is_current"])]
+    if record.empty:
+        raise HTTPException(status_code=404, detail="Account not found")
+    return record.iloc[0].to_dict()
+
+
+@router.post("/users/{user_id}/assign-account")
+def assign_account_to_user(user_id: UUID, account_id: UUID):
+    mark_old_version_as_stale("users", user_id, "user_id")
+    users = load_versions("users")
+    current = users[users["user_id"] == str(user_id)].iloc[-1].to_dict()
+    updated = User(
+        **{k: current[k] for k in User.model_fields if k in current},
+        account_id=account_id,
+        updated_at=datetime.now(timezone.utc),
+        is_current=True
+    )
+    save_version(updated, "users", "user_id")
+    return {"message": "User assigned to account", "user_id": str(user_id), "account_id": str(account_id)}

--- a/app/api/household.py
+++ b/app/api/household.py
@@ -1,0 +1,85 @@
+from fastapi import APIRouter, HTTPException
+from uuid import UUID, uuid4
+from datetime import datetime, timezone
+from app.models.schemas import Household, User
+from app.services.storage import save_version, mark_old_version_as_stale, load_versions
+
+router = APIRouter()
+
+@router.post("/")
+def create_household(name: str):
+    household = Household(
+        household_id=uuid4(),
+        name=name,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        is_current=True,
+        is_deleted=False
+    )
+    save_version(household, "households", "household_id")
+    return {"message": "Household created", "household_id": str(household.household_id)}
+
+
+@router.put("/{household_id}")
+def update_household(household_id: UUID, name: str):
+    mark_old_version_as_stale("households", household_id, "household_id")
+    households = load_versions("households")
+    current = households[households["household_id"] == str(household_id)].iloc[-1].to_dict()
+    updated = Household(
+        household_id=household_id,
+        name=name,
+        created_at=current["created_at"],
+        updated_at=datetime.now(timezone.utc),
+        is_current=True,
+        is_deleted=False
+    )
+    save_version(updated, "households", "household_id")
+    return {"message": "Household updated", "household_id": str(household_id)}
+
+
+@router.post("/{household_id}/delete")
+def soft_delete_household(household_id: UUID):
+    mark_old_version_as_stale("households", household_id, "household_id")
+    households = load_versions("households")
+    current = households[households["household_id"] == str(household_id)].iloc[-1].to_dict()
+    deleted = Household(
+        household_id=household_id,
+        name=current["name"],
+        created_at=current["created_at"],
+        updated_at=datetime.now(timezone.utc),
+        is_current=True,
+        is_deleted=True
+    )
+    save_version(deleted, "households", "household_id")
+    return {"message": "Household deleted", "household_id": str(household_id)}
+
+
+@router.get("/")
+def list_households():
+    households = load_versions("households")
+    current = households[(households["is_current"] == True) & (households["is_deleted"] == False)]
+    return current.to_dict(orient="records")
+
+
+@router.get("/{household_id}")
+def get_household(household_id: UUID):
+    households = load_versions("households")
+    record = households[(households["household_id"] == str(household_id)) & (households["is_current"])]
+    if record.empty:
+        raise HTTPException(status_code=404, detail="Household not found")
+    return record.iloc[0].to_dict()
+
+
+@router.post("/users/{user_id}/assign-household")
+def assign_household_to_user(user_id: UUID, household_id: UUID):
+    mark_old_version_as_stale("users", user_id, "user_id")
+    users = load_versions("users")
+    current = users[users["user_id"] == str(user_id)].iloc[-1].to_dict()
+    updated = User(
+        **{k: current[k] for k in User.model_fields if k in current},
+        household_id=household_id,
+        updated_at=datetime.now(timezone.utc),
+        is_current=True
+    )
+    save_version(updated, "users", "user_id")
+    return {"message": "User assigned to household", "user_id": str(user_id), "household_id": str(household_id)}

--- a/app/api/summaries.py
+++ b/app/api/summaries.py
@@ -1,0 +1,47 @@
+from fastapi import APIRouter, Depends, Query, HTTPException
+import pandas as pd
+from app.services.storage import load_versions, resolve_name_by_id
+from app.services.auth import get_current_user
+
+router = APIRouter()
+
+@router.get("/summary")
+def get_entry_summary(
+    month: str = Query(..., description="Month in YYYY-MM format"),
+    type: str = Query(None, description="Optional filter: income or expense"),
+    user=Depends(get_current_user)
+):
+    df = load_versions("entries")
+
+    # Filter only current, non-deleted entries
+    df = df[(df["is_current"]) & (~df["is_deleted"])]
+
+    # Filter by month
+    try:
+        month_start = pd.to_datetime(month + "-01")
+        month_end = (month_start + pd.offsets.MonthEnd(1))
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid month format, expected YYYY-MM")
+
+    df = df[(pd.to_datetime(df["entry_date"]) >= month_start) & (pd.to_datetime(df["entry_date"]) <= month_end)]
+
+    # Optional filter by type (income/expense)
+    if type:
+        df = df[df["type"] == type]
+
+    if df.empty:
+        return {"message": "No entries found", "summary": {}}
+
+    # Resolve account/household names for grouping
+    df["account_name"] = df["account_id"].apply(lambda x: resolve_name_by_id("accounts", x, "account_id"))
+    df["household_name"] = df["household_id"].apply(lambda x: resolve_name_by_id("households", x, "household_id"))
+
+    # Aggregate summaries
+    summary = {
+        "by_category": df.groupby("category")["amount"].sum().to_dict(),
+        "by_account": df.groupby("account_name")["amount"].sum().to_dict(),
+        "by_household": df.groupby("household_name")["amount"].sum().to_dict(),
+        "total": df["amount"].sum()
+    }
+
+    return {"month": month, "type": type, "summary": summary}

--- a/app/import_entries.py
+++ b/app/import_entries.py
@@ -1,0 +1,45 @@
+import argparse
+import pandas as pd
+from uuid import uuid4
+from datetime import datetime, timezone
+from app.models.schemas import Entry
+from app.services.storage import save_version, resolve_id_by_name
+from app.services.auth import get_user_by_token
+
+def import_entries_from_csv(csv_path: str, token: str):
+    df = pd.read_csv(csv_path)
+    user = get_user_by_token(token)
+
+    for _, row in df.iterrows():
+        account_id = resolve_id_by_name("accounts", row["account_name"], "account_id")
+        household_id = resolve_id_by_name("households", row["household_name"], "household_id")
+
+        entry = Entry(
+            entry_id=uuid4(),
+            user_id=user["user_id"],
+            account_id=account_id,
+            household_id=household_id,
+            account_name=row["account_name"],
+            household_name=row["household_name"],
+            entry_date=pd.to_datetime(row["entry_date"]).date(),
+            value_date=pd.to_datetime(row["value_date"]).date(),
+            type=row["type"],
+            category=row["category"],
+            amount=row["amount"],
+            description=row.get("description", ""),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            is_current=True
+        )
+
+        save_version(entry, "entries", "entry_id")
+
+    print(f"Imported {len(df)} entries from {csv_path}")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Import entries from CSV into S3.")
+    parser.add_argument("csv_path", help="Path to CSV file")
+    parser.add_argument("token", help="User auth token")
+
+    args = parser.parse_args()
+    import_entries_from_csv(args.csv_path, args.token)

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,10 @@
 from fastapi import FastAPI
-from app.api import entries, users
+from app.api import entries, users, household, accounts, summaries
 
 app = FastAPI()
 
 app.include_router(entries.router, prefix="/entries", tags=["Entries"])
 app.include_router(users.router, prefix="/users", tags=["Users"])
+app.include_router(household.router, prefix="/households", tags=["Households"])
+app.include_router(accounts.router, prefix="/accounts", tags=["Accounts"])
+app.include_router(summaries.router, prefix="/summaries", tags=["summaries"])

--- a/app/models/enums.py
+++ b/app/models/enums.py
@@ -24,4 +24,8 @@ class Category(str, Enum):
     restaurants = "restaurants"
     bills = "bills"
     extraordinary_expenses = "extraordinary_expenses"
+    extraordinary_incomes = "extraordinary_incomes"
+    academic = "academic"
+    presents = "presents"
+    vehicles = "vehicles"
     other = "other"

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -6,13 +6,18 @@ from datetime import datetime, timezone, date
 
 class Entry(BaseModel):
     entry_id: UUID = Field(default_factory=uuid4)
-    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    user_id: UUID
+    account_id: UUID | None = None
+    household_id: UUID | None = None
+    account_name: str
+    household_name: str
     entry_date: date
     value_date: date
     type: EntryType
     category: Category
     amount: float
     description: str = ""
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     is_current: bool = True
 
@@ -45,3 +50,19 @@ class UserUpdateRequest(BaseModel):
     user_name: str | None = None
     email: EmailStr | None = None
     password: str | None = None
+
+class Household(BaseModel):
+    household_id: UUID = Field(default_factory=uuid4)
+    name: str
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    is_current: bool = True
+
+class Account(BaseModel):
+    account_id: UUID = Field(default_factory=uuid4)
+    name: str
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    is_current: bool = True
+    is_deleted: bool = False
+

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -54,3 +54,17 @@ def load_versions(record_type: str) -> pd.DataFrame:
         partitioning="hive"
     )
     return dataset.to_table().to_pandas()
+
+def resolve_id_by_name(record_type: str, name: str, id_field: str) -> str:
+    df = load_versions(record_type)
+
+    match = df[
+        (df["name"].str.lower() == name.lower()) &
+        (df["is_current"] == True) &
+        (~df["is_deleted"].fillna(False))
+    ]
+
+    if match.empty:
+        raise HTTPException(status_code=404, detail=f"{record_type[:-1].capitalize()} '{name}' not found")
+
+    return match.iloc[0][id_field]


### PR DESCRIPTION
Introduces new FastAPI routers for managing accounts and households, including creation, update, soft-delete, and assignment to users. Adds endpoints for entry summaries and a script for importing entries from CSV. Updates entry creation logic to resolve account and household IDs by name and enforces user/account/household consistency. Expands enums and schemas to support new categories and models, and adds utility functions for resolving IDs by name.