### PR TITLE
HF-14-Audit-logging

### DIFF
--- a/app/api/accounts.py
+++ b/app/api/accounts.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException, Depends
 from uuid import UUID, uuid4
 from datetime import datetime, timezone
 from app.models.schemas import Account, Household, User, UserAccount
-from app.services.storage import load_versions, save_version, mark_old_version_as_stale, soft_delete_record
+from app.services.storage import load_versions, save_version, mark_old_version_as_stale, soft_delete_record, log_action
 from app.services.auth import get_current_user
 
 router = APIRouter()
@@ -21,10 +21,11 @@ def create_account(payload: Account, user=Depends(get_current_user)):
         is_deleted=False,
     )
     save_version(account, "accounts", "account_id")
-
+    log_action(user["user_id"], "create", "accounts", str(account.account_id), payload.model_dump())
     # Automatically assign the creator as a member
     mapping = UserAccount(user_id=user["user_id"], account_id=account.account_id)
     save_version(mapping, "user_accounts", "mapping_id")
+    log_action(user["user_id"], "assign_user", "accounts", str(account.account_id), {"user_id": str(payload.user_id)})
 
     return {"message": "Account created", "account_id": str(account.account_id)}
 
@@ -32,10 +33,11 @@ def create_account(payload: Account, user=Depends(get_current_user)):
 def assign_user_to_account(user_id: UUID, account_id: UUID, user=Depends(get_current_user)):
     mapping = UserAccount(user_id=user_id, account_id=account_id)
     save_version(mapping, "user_accounts", "mapping_id")
+    log_action(user["user_id"], "assign_user", "accounts", str(account_id), {"user_id": str(user_id)})
     return {"message": "User assigned to account"}
 
 @router.put("/{account_id}")
-def update_account(account_id: UUID, name: str):
+def update_account(account_id: UUID, name: str, user=Depends(get_current_user)):
     mark_old_version_as_stale("accounts", account_id, "account_id")
     accounts = load_versions("accounts", Account)
     current = accounts[accounts["account_id"] == str(account_id)].iloc[-1].to_dict()
@@ -48,11 +50,14 @@ def update_account(account_id: UUID, name: str):
         is_deleted=False
     )
     save_version(updated, "accounts", "account_id")
+    log_action(user["user_id"], "update", "accounts", str(account_id), {"name": name})
+
     return {"message": "Account updated", "account_id": str(account_id)}
 
 
 @router.delete("/{account_id}")
 def delete_account(account_id: UUID, user=Depends(get_current_user)):
+
     return soft_delete_record(
         "accounts", str(account_id), "account_id", Account,
         user=user, owner_field="user_id", require_owner=True
@@ -60,9 +65,10 @@ def delete_account(account_id: UUID, user=Depends(get_current_user)):
 
 
 @router.get("/")
-def list_accounts():
+def list_accounts(user=Depends(get_current_user)):
     accounts = load_versions("accounts", Account)
     current = accounts[(accounts["is_current"] == True) & (accounts["is_deleted"] == False)]
+    log_action(user["user_id"], "list", "accounts", None, {"count": len(current)})
     return current.to_dict(orient="records")
 
 @router.get("/memberships")
@@ -77,13 +83,15 @@ def list_account_memberships(user=Depends(get_current_user)):
         (df["is_current"]) &
         (~df.get("is_deleted", False).fillna(False))
     ]
-
+    log_action(user["user_id"], "list", "account_membership", None, {"count": len(df)})
     return df.to_dict(orient="records")
 
 @router.get("/{account_id}")
-def get_account(account_id: UUID):
+def get_account(account_id: UUID, user=Depends(get_current_user)):
     accounts = load_versions("accounts", Account)
     record = accounts[(accounts["account_id"] == str(account_id)) & (accounts["is_current"])]
     if record.empty:
         raise HTTPException(status_code=404, detail="Account not found")
+    
+    log_action(user["user_id"], "get", "accounts", str(account_id))
     return record.iloc[0].to_dict()

--- a/app/api/accounts.py
+++ b/app/api/accounts.py
@@ -25,7 +25,7 @@ def create_account(payload: Account, user=Depends(get_current_user)):
     # Automatically assign the creator as a member
     mapping = UserAccount(user_id=user["user_id"], account_id=account.account_id)
     save_version(mapping, "user_accounts", "mapping_id")
-    log_action(user["user_id"], "assign_user", "accounts", str(account.account_id), {"user_id": str(payload.user_id)})
+    log_action(user["user_id"], "assign_user", "accounts", str(account.account_id), {"user_id": str(user["user_id"])})
 
     return {"message": "Account created", "account_id": str(account.account_id)}
 

--- a/app/api/audit.py
+++ b/app/api/audit.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, Depends, Query
+import pandas as pd
+from app.services.storage import load_versions
+from app.models.schemas import AuditLog
+from app.services.auth import get_current_user
+
+router = APIRouter()
+
+@router.get("/logs")
+def list_audit_logs(
+    user_id: str | None = Query(None),
+    resource_type: str | None = Query(None),
+    action: str | None = Query(None),
+    start: str | None = Query(None),
+    end: str | None = Query(None),
+    user=Depends(get_current_user)
+):
+    df = load_versions("audit_logs", AuditLog)
+    if df.empty:
+        return []
+
+    df = df[df["is_current"] & ~df["is_deleted"].fillna(False)]
+
+    if user_id:
+        df = df[df["user_id"] == user_id]
+    if resource_type:
+        df = df[df["resource_type"] == resource_type]
+    if action:
+        df = df[df["action"] == action]
+    if start and end:
+        start_dt, end_dt = pd.to_datetime(start), pd.to_datetime(end)
+        df = df[(df["timestamp"] >= start_dt) & (df["timestamp"] <= end_dt)]
+
+    return df.to_dict(orient="records")

--- a/app/api/audit.py
+++ b/app/api/audit.py
@@ -15,7 +15,11 @@ def list_audit_logs(
     end: str | None = Query(None),
     user=Depends(get_current_user)
 ):
-    df = load_versions("audit_logs", AuditLog)
+    start_dt, end_dt = None, None
+    if start and end:
+        start_dt, end_dt = pd.to_datetime(start), pd.to_datetime(end)
+
+    df = load_versions("audit_logs", AuditLog, start=start_dt, end=end_dt)
     if df.empty:
         return []
 
@@ -27,8 +31,5 @@ def list_audit_logs(
         df = df[df["resource_type"] == resource_type]
     if action:
         df = df[df["action"] == action]
-    if start and end:
-        start_dt, end_dt = pd.to_datetime(start), pd.to_datetime(end)
-        df = df[(df["timestamp"] >= start_dt) & (df["timestamp"] <= end_dt)]
 
     return df.to_dict(orient="records")

--- a/app/api/household.py
+++ b/app/api/household.py
@@ -23,7 +23,7 @@ def create_household(payload: Household, user=Depends(get_current_user)):
     # Automatically assign the creator as a member
     mapping = UserHousehold(user_id=user["user_id"], household_id=household.household_id)
     save_version(mapping, "user_households", "mapping_id")
-    log_action(user["user_id"], "assign_user", "households", str(household.household_id), {"user_id": str(user.user_id)})
+    log_action(user["user_id"], "assign_user", "households", str(household.household_id), {"user_id": str(user["user_id"])})
 
     return {"message": "Household created", "household_id": str(household.household_id)}
 

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -7,7 +7,7 @@ import re
 from uuid import UUID, uuid4
 import jwt
 from app.models.schemas import RegisterRequest, LoginRequest, UserUpdateRequest, User, RefreshToken, UserAccount, UserHousehold
-from app.services.storage import load_versions, save_version, mark_old_version_as_stale, soft_delete_record
+from app.services.storage import load_versions, save_version, mark_old_version_as_stale, soft_delete_record, log_action
 from app.services.auth import get_current_user, create_access_token, create_refresh_token, SECRET_KEY, ALGORITHM
 
 router = APIRouter()
@@ -32,6 +32,8 @@ def register_user(request: RegisterRequest):
     )
 
     save_version(new_user, "users", "user_id")
+    log_action(None, "register", "users", str(user.user_id), payload.model_dump())
+
     return {
         "message": "User registered successfully",
         "user_id": str(new_user.user_id)
@@ -55,6 +57,7 @@ def login_user(request: LoginRequest):
     access_token = create_access_token({"sub": user.user_id})
     refresh_token = create_refresh_token(user.user_id)
 
+    log_action(user["user_id"], "login", "users", str(user["user_id"]))
     return {
         "message": "Login successful",
         "user_id": user["user_id"],
@@ -83,6 +86,7 @@ def update_user(user_id: UUID, update: UserUpdateRequest, user=Depends(get_curre
     )
 
     save_version(updated_user, "users", "user_id")
+    log_action(user["user_id"], "update", "users", str(user_id), update.model_dump())
     return {"message": "User updated successfully", "user_id": str(user_id)}
 
 
@@ -169,7 +173,8 @@ def change_password(current_password: str, new_password: str, user=Depends(get_c
 
     for _, token in user_tokens.iterrows():
         mark_old_version_as_stale("refresh_tokens", token["refresh_token_id"], "refresh_token_id")
-
+    
+    log_action(user["user_id"], "change_password", "users", str(user["user_id"]))
     return {"message": "Password changed successfully. Please log in again."}
 
 @router.get("/{user_id}")
@@ -184,5 +189,5 @@ def get_user(user_id: str, user=Depends(get_current_user)):
 
     if match.empty:
         raise HTTPException(status_code=404, detail="User not found")
-
+    log_action(user["user_id"], "get", "user", str(user_id))
     return match.iloc[0].to_dict()

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -32,7 +32,7 @@ def register_user(request: RegisterRequest):
     )
 
     save_version(new_user, "users", "user_id")
-    log_action(None, "register", "users", str(new_user.user_id), request.model_dump())
+    log_action(str(new_user.user_id), "register", "users", str(new_user.user_id), request.model_dump())
 
     return {
         "message": "User registered successfully",

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -32,7 +32,7 @@ def register_user(request: RegisterRequest):
     )
 
     save_version(new_user, "users", "user_id")
-    log_action(None, "register", "users", str(user.user_id), payload.model_dump())
+    log_action(None, "register", "users", str(new_user.user_id), request.model_dump())
 
     return {
         "message": "User registered successfully",

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from app.api import entries, users, household, accounts, summaries, debts
+from app.api import entries, users, household, accounts, summaries, debts, audit
 
 app = FastAPI()
 
@@ -8,4 +8,5 @@ app.include_router(debts.router, prefix="/debts", tags=["Debts"])
 app.include_router(users.router, prefix="/users", tags=["Users"])
 app.include_router(household.router, prefix="/households", tags=["Households"])
 app.include_router(accounts.router, prefix="/accounts", tags=["Accounts"])
+app.include_router(audit.router, prefix="/audit", tags=["Audit"])
 app.include_router(summaries.router, prefix="/summaries", tags=["Summaries"])

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -141,3 +141,14 @@ class DebtCreate(BaseModel):
     installments: int
     start_date: date
     due_day: int   # day of month for payments
+
+class AuditLog(BaseModel):
+    log_id: UUID = Field(default_factory=uuid4)
+    user_id: str | None = None       # who performed action (optional for system tasks)
+    action: str                      # "create", "update", "delete", "login", etc.
+    resource_type: str               # "users", "accounts", "entries", etc.
+    resource_id: str | None = None   # affected record
+    details: dict | None = None      # request payload, old vs. new values, etc.
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    is_current: bool = True
+    is_deleted: bool = False

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -148,7 +148,7 @@ class AuditLog(BaseModel):
     action: str                      # "create", "update", "delete", "login", etc.
     resource_type: str               # "users", "accounts", "entries", etc.
     resource_id: str | None = None   # affected record
-    details: dict | None = None      # request payload, old vs. new values, etc.
+    details: str | None = None      # request payload, old vs. new values, etc.
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     is_current: bool = True
     is_deleted: bool = False

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -187,6 +187,7 @@ def soft_delete_record(
     # instantiate model and save
     deleted_obj = model_cls(**data)
     save_version(deleted_obj, record_type, id_field)
+    log_action(user.get("user_id") if user else None, "delete", record_type, str(record_id))
 
     # Built-in cascades:
     if record_type == "users":
@@ -212,6 +213,7 @@ def _cascade_user_deletion(user_id: str, now: datetime):
         data = r.to_dict()
         data.update({"updated_at": now, "is_current": True, "is_deleted": True})
         save_version(UserAccount(**data), "user_accounts", "mapping_id")
+        log_action(user_id, "cascade_delete", "account_membership", r["mapping_id"])
 
     # user_households
     uh_df = load_versions("user_households", UserHousehold)
@@ -225,6 +227,7 @@ def _cascade_user_deletion(user_id: str, now: datetime):
         data = r.to_dict()
         data.update({"updated_at": now, "is_current": True, "is_deleted": True})
         save_version(UserHousehold(**data), "user_households", "mapping_id")
+        log_action(user_id, "cascade_delete", "household_membership", r["mapping_id"])
 
     # refresh_tokens (invalidate)
     rt_df = load_versions("refresh_tokens", RefreshToken)
@@ -271,3 +274,15 @@ def _cascade_debt_deletion(debt_id: str, debt_row: pd.Series, now: datetime):
         data = row.to_dict()
         data.update({"updated_at": now, "is_current": True, "is_deleted": True})
         save_version(Entry(**data), "entries", "entry_id")
+        log_action(user_id if user_id else None, "cascade_delete", "entries", row["entry_id"])
+
+def log_action(user_id: str | None, action: str, resource_type: str, resource_id: str | None, details: dict | None = None):
+    from app.models.schemas import AuditLog
+    entry = AuditLog(
+        user_id=user_id,
+        action=action,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        details=details,
+    )
+    save_version(entry, "audit_logs", "log_id")

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -251,7 +251,8 @@ def _cascade_debt_deletion(debt_id: str, debt_row: pd.Series, now: datetime):
     """
 
     entries_df = load_versions("entries", Entry)
-
+    debt_name = debt_row.get("name", "")
+    user_id = debt_row.get("user_id")
     # If entries include debt_id column, prefer that
     if "debt_id" in entries_df.columns:
         sel = entries_df[
@@ -261,8 +262,6 @@ def _cascade_debt_deletion(debt_id: str, debt_row: pd.Series, now: datetime):
         ]
     else:
         # fallback: match by description (best-effort)
-        debt_name = debt_row.get("name", "")
-        user_id = debt_row.get("user_id")
         sel = entries_df[
             (entries_df["description"].str.contains(str(debt_name), na=False)) &
             (entries_df["user_id"] == str(user_id)) &

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -102,7 +102,7 @@ def _empty_df(schema):
 
 def load_versions(
     record_type: str,
-    model_class,
+    schema,
     record_id: str | None = None,
     start: datetime | None = None,
     end: datetime | None = None

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -296,6 +296,6 @@ def log_action(user_id: str | None, action: str, resource_type: str, resource_id
         action=action,
         resource_type=resource_type,
         resource_id=resource_id,
-        details=details,
+        details=details_json,
     )
     save_version(entry, "audit_logs", "log_id")

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -120,7 +120,7 @@ def load_versions(
                 keys.append(obj["Key"])
             current += timedelta(days=1)
     elif record_id:
-        prefix = f"{record_type}/{model_class.__name__.lower()}_id={record_id}/"
+        prefix = f"{record_type}/{schema.__name__.lower()}_id={record_id}/"
         resp = s3.list_objects_v2(Bucket=BUCKET_NAME, Prefix=prefix)
         keys = [obj["Key"] for obj in resp.get("Contents", [])]
     else:
@@ -128,7 +128,7 @@ def load_versions(
         keys = [obj["Key"] for obj in resp.get("Contents", [])]
 
     if not keys:
-        return pd.DataFrame(columns=model_class.model_fields.keys())
+        return pd.DataFrame(columns=schema.model_fields.keys())
 
     dfs = []
     for key in keys:

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -5,7 +5,7 @@ import json
 import io
 import pyarrow as pa
 import botocore
-from datetime import datetime, timezone
+from datetime import datetime, timezone, date
 import pyarrow.dataset as ds
 import pandas as pd
 from typing import Type, Optional
@@ -284,7 +284,7 @@ def log_action(user_id: str | None, action: str, resource_type: str, resource_id
     for k, v in (details or {}).items():
         if isinstance(v, UUID):
             normalized[k] = str(v)
-        elif isinstance(v, datetime):
+        elif isinstance(v, (datetime, date)):
             normalized[k] = v.isoformat()
         else:
             normalized[k] = v

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -1,6 +1,7 @@
 from uuid import UUID, uuid4
 import pyarrow.parquet as pq
 import boto3
+import json
 import io
 import pyarrow as pa
 import botocore
@@ -287,6 +288,8 @@ def log_action(user_id: str | None, action: str, resource_type: str, resource_id
             normalized[k] = v.isoformat()
         else:
             normalized[k] = v
+
+    details_json = json.dumps(normalized) 
 
     entry = AuditLog(
         user_id=user_id,

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -275,7 +275,7 @@ def _cascade_debt_deletion(debt_id: str, debt_row: pd.Series, now: datetime):
         data = row.to_dict()
         data.update({"updated_at": now, "is_current": True, "is_deleted": True})
         save_version(Entry(**data), "entries", "entry_id")
-        log_action(user_id if user_id else None, "cascade_delete", "entries", row["entry_id"])
+        log_action(user_id, "cascade_delete", "entries", row["entry_id"])
 
 def log_action(user_id: str | None, action: str, resource_type: str, resource_id: str | None, details: dict | None = None):
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,25 @@
+import pytest
+from fastapi.testclient import TestClient
+from uuid import uuid4
+from datetime import date
+
+def test_audit_logs(client: TestClient):
+    # Register user
+    payload = {"email": f"audit-{uuid4().hex[:6]}@example.com", "user_name": "audituser", "password": "Audit123!"}
+    r = client.post("/users/register", json=payload)
+    user_id = r.json()["user_id"]
+
+    # Login
+    r = client.post("/users/login", json={"email": payload["email"], "password": payload["password"]})
+    tokens = r.json()
+    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+
+    # Create household
+    r = client.post("/households/", json={"name": "Audit Household"}, headers=headers)
+    household_id = r.json()["household_id"]
+
+    # Query audit logs
+    r = client.get("/audit/logs", headers=headers)
+    logs = r.json()
+    assert any(l["action"] == "register" and l["resource_type"] == "users" for l in logs)
+    assert any(l["action"] == "create" and l["resource_type"] == "households" for l in logs)

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -47,9 +47,9 @@ def test_audit_log_partitioning(client):
 
     # --- Fetch logs using the API (authorized) ---
     r = client.get("/audit/logs", params={"user_id": user_id}, headers=headers)
-    print("Audit logs returned:", logs)
     assert r.status_code == 200
     logs = r.json()
+    print("Audit logs returned:", logs)
     assert len(logs) > 0
 
     # --- Validate today’s date is present ---

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,7 +1,11 @@
 import pytest
 from fastapi.testclient import TestClient
 from uuid import uuid4
-from datetime import date
+import pandas as pd
+import io
+from datetime import date, datetime, timezone
+from app.services import storage
+from app.models.schemas import AuditLog
 
 def test_audit_logs(client: TestClient):
     # Register user
@@ -23,3 +27,29 @@ def test_audit_logs(client: TestClient):
     logs = r.json()
     assert any(l["action"] == "register" and l["resource_type"] == "users" for l in logs)
     assert any(l["action"] == "create" and l["resource_type"] == "households" for l in logs)
+
+def test_audit_log_partitioning(client):
+    # Trigger an action that generates an audit log
+    payload = {
+        "email": f"partition-{uuid4().hex[:6]}@example.com",
+        "user_name": "puser",
+        "password": "Part123!"
+    }
+    r = client.post("/users/register", json=payload)
+    assert r.status_code == 200
+    user_id = r.json()["user_id"]
+
+    # Fetch logs using the API
+    r = client.get("/audit/logs", params={"user_id": user_id})
+    assert r.status_code == 200
+    logs = r.json()
+    assert len(logs) > 0
+
+    # Validate at least one log has today's date
+    now = datetime.now(timezone.utc).date()
+    timestamps = [pd.to_datetime(log["timestamp"]).date() for log in logs]
+    assert any(ts == now for ts in timestamps)
+
+    # Extra: validate the log contains action + resource_type
+    assert any(log["action"] == "register" and log["resource_type"] == "users" for log in logs)
+

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -2,10 +2,7 @@ import pytest
 from fastapi.testclient import TestClient
 from uuid import uuid4
 import pandas as pd
-import io
 from datetime import date, datetime, timezone
-from app.services import storage
-from app.models.schemas import AuditLog
 
 def test_audit_logs(client: TestClient):
     # Register user
@@ -28,9 +25,7 @@ def test_audit_logs(client: TestClient):
     assert any(l["action"] == "register" and l["resource_type"] == "users" for l in logs)
     assert any(l["action"] == "create" and l["resource_type"] == "households" for l in logs)
 
-from uuid import uuid4
-from datetime import datetime, timezone
-import pandas as pd
+
 
 def test_audit_log_partitioning(client):
     # --- Register user (this generates an audit log) ---
@@ -52,6 +47,7 @@ def test_audit_log_partitioning(client):
 
     # --- Fetch logs using the API (authorized) ---
     r = client.get("/audit/logs", params={"user_id": user_id}, headers=headers)
+    print("Audit logs returned:", logs)
     assert r.status_code == 200
     logs = r.json()
     assert len(logs) > 0

--- a/tests/test_debts.py
+++ b/tests/test_debts.py
@@ -49,6 +49,13 @@ def test_debt_creates_entries(client: TestClient):
     assert r.status_code == 200
     assert r.json()["installments"] == 4
 
+    # --- Fetch logs filtered by resource_type ---
+    r = client.get("/audit/logs", params={"resource_type": "debts", "user_id": user_id})
+    assert r.status_code == 200
+    logs = r.json()
+    assert any(log["resource_type"] == "debts" for log in logs)
+    assert any("Car Loan" in log["details"] for log in logs)
+
     # --- Verify entries were created ---
     r = client.get("/entries/", headers=headers)
     entries = r.json()

--- a/tests/test_debts.py
+++ b/tests/test_debts.py
@@ -50,7 +50,7 @@ def test_debt_creates_entries(client: TestClient):
     assert r.json()["installments"] == 4
 
     # --- Fetch logs filtered by resource_type ---
-    r = client.get("/audit/logs", params={"resource_type": "debts", "user_id": user_id})
+    r = client.get("/audit/logs", params={"resource_type": "debts", "user_id": user_id}, headers=headers)
     assert r.status_code == 200
     logs = r.json()
     assert any(log["resource_type"] == "debts" for log in logs)


### PR DESCRIPTION
Introduces audit logging across all major API endpoints by adding log_action calls to record create, update, delete, assign, and list actions. Adds AuditLog schema and /audit/logs API for querying logs. Updates storage service to log cascaded deletions. Includes tests for audit log functionality.